### PR TITLE
feature(config-map): add "injection" points for launch to add config map

### DIFF
--- a/maven/Release/Jenkinsfile
+++ b/maven/Release/Jenkinsfile
@@ -2,6 +2,9 @@
 @Library('github.com/fabric8io/fabric8-pipeline-library@master')
 def canaryVersion = "1.0.${env.BUILD_NUMBER}"
 def utils = new io.fabric8.Utils()
+
+// INJECT FRAGMENT setup
+
 mavenNode {
   checkout scm
   if (utils.isCI()){

--- a/maven/ReleaseAndStage/Jenkinsfile
+++ b/maven/ReleaseAndStage/Jenkinsfile
@@ -6,6 +6,8 @@ def stashName = "buildpod.${env.JOB_NAME}.${env.BUILD_NUMBER}".replace('-', '_')
 def envStage = utils.environmentNamespace('stage')
 def envProd = utils.environmentNamespace('run')
 
+// INJECT FRAGMENT setup
+
 mavenNode {
   checkout scm
   if (utils.isCI()){

--- a/maven/ReleaseStageApproveAndPromote/Jenkinsfile
+++ b/maven/ReleaseStageApproveAndPromote/Jenkinsfile
@@ -6,6 +6,8 @@ def stashName = "buildpod.${env.JOB_NAME}.${env.BUILD_NUMBER}".replace('-', '_')
 def envStage = utils.environmentNamespace('stage')
 def envProd = utils.environmentNamespace('run')
 
+// INJECT FRAGMENT setup
+
 mavenNode {
   checkout scm
   if (utils.isCI()){


### PR DESCRIPTION
To be able to install services prior to building the booster we add this injection point so that launch has a place marker to add jenkins 'snippets'