### PR TITLE
Fix: maven integration tests

### DIFF
--- a/maven/Release/Jenkinsfile
+++ b/maven/Release/Jenkinsfile
@@ -9,11 +9,12 @@ mavenNode {
   if (utils.isCI()) {
 
     mavenCI {
-        integrationTestCmd = "mvn org.apache.maven.plugins:maven-failsafe-plugin:integration-test \
-                            -Dnamespace.use.current=false -Dnamespace.use.existing=${utils.testNamespace()} \
-                            -Dit.test=*IT -DfailIfNoTests=false -DenableImageStreamDetection=true \
-                            org.apache.maven.plugins:maven-failsafe-plugin:verify \
-                            -P openshift-it"
+        integrationTestCmd =
+             "mvn org.apache.maven.plugins:maven-failsafe-plugin:integration-test \
+                org.apache.maven.plugins:maven-failsafe-plugin:verify \
+                -Dnamespace.use.current=false -Dnamespace.use.existing=${utils.testNamespace()} \
+                -Dit.test=*IT -DfailIfNoTests=false -DenableImageStreamDetection=true \
+                -P openshift-it"
     }
 
   } else if (utils.isCD()) {

--- a/maven/Release/Jenkinsfile
+++ b/maven/Release/Jenkinsfile
@@ -8,8 +8,14 @@ mavenNode {
   checkout scm
   if (utils.isCI()) {
 
-    mavenCI{}
-    
+    mavenCI {
+        integrationTestCmd = "mvn org.apache.maven.plugins:maven-failsafe-plugin:integration-test \
+                            -Dnamespace.use.current=false -Dnamespace.use.existing=${utils.testNamespace()} \
+                            -Dit.test=*IT -DfailIfNoTests=false -DenableImageStreamDetection=true \
+                            org.apache.maven.plugins:maven-failsafe-plugin:verify \
+                            -P openshift-it"
+    }
+
   } else if (utils.isCD()) {
     echo 'NOTE: running pipelines for the first time will take longer as build and base docker images are pulled onto the node'
     container(name: 'maven') {

--- a/maven/ReleaseAndStage/Jenkinsfile
+++ b/maven/ReleaseAndStage/Jenkinsfile
@@ -13,11 +13,12 @@ mavenNode {
   if (utils.isCI()) {
 
     mavenCI {
-        integrationTestCmd = "mvn org.apache.maven.plugins:maven-failsafe-plugin:integration-test \
-                            -Dnamespace.use.current=false -Dnamespace.use.existing=${utils.testNamespace()} \
-                            -Dit.test=*IT -DfailIfNoTests=false -DenableImageStreamDetection=true \
-                            org.apache.maven.plugins:maven-failsafe-plugin:verify \
-                            -P openshift-it"
+        integrationTestCmd =
+         "mvn org.apache.maven.plugins:maven-failsafe-plugin:integration-test \
+            org.apache.maven.plugins:maven-failsafe-plugin:verify \
+            -Dnamespace.use.current=false -Dnamespace.use.existing=asds \
+            -Dit.test=*IT -DfailIfNoTests=false -DenableImageStreamDetection=true \
+            -P openshift-it"
     }
 
   } else if (utils.isCD()) {

--- a/maven/ReleaseAndStage/Jenkinsfile
+++ b/maven/ReleaseAndStage/Jenkinsfile
@@ -12,8 +12,14 @@ mavenNode {
   checkout scm
   if (utils.isCI()) {
 
-    mavenCI{}
-    
+    mavenCI {
+        integrationTestCmd = "mvn org.apache.maven.plugins:maven-failsafe-plugin:integration-test \
+                            -Dnamespace.use.current=false -Dnamespace.use.existing=${utils.testNamespace()} \
+                            -Dit.test=*IT -DfailIfNoTests=false -DenableImageStreamDetection=true \
+                            org.apache.maven.plugins:maven-failsafe-plugin:verify \
+                            -P openshift-it"
+    }
+
   } else if (utils.isCD()) {
     /*
      * Try to load the script ".openshiftio/Jenkinsfile.setup.groovy".
@@ -28,7 +34,7 @@ mavenNode {
     } catch (Exception ex) {
       echo "Jenkinsfile.setup.groovy not found"
     }
-    
+
     echo 'NOTE: running pipelines for the first time will take longer as build and base docker images are pulled onto the node'
     container(name: 'maven') {
       stage('Build Release') {

--- a/maven/ReleaseStageApproveAndPromote/Jenkinsfile
+++ b/maven/ReleaseStageApproveAndPromote/Jenkinsfile
@@ -13,11 +13,12 @@ mavenNode {
   if (utils.isCI()) {
 
     mavenCI {
-        integrationTestCmd = "mvn org.apache.maven.plugins:maven-failsafe-plugin:integration-test \
-                            -Dnamespace.use.current=false -Dnamespace.use.existing=${utils.testNamespace()} \
-                            -Dit.test=*IT -DfailIfNoTests=false -DenableImageStreamDetection=true \
-                            org.apache.maven.plugins:maven-failsafe-plugin:verify \
-                            -P openshift-it"
+        integrationTestCmd =
+         "mvn org.apache.maven.plugins:maven-failsafe-plugin:integration-test \
+            org.apache.maven.plugins:maven-failsafe-plugin:verify \
+            -Dnamespace.use.current=false -Dnamespace.use.existing=asds \
+            -Dit.test=*IT -DfailIfNoTests=false -DenableImageStreamDetection=true \
+            -P openshift-it"
     }
 
   } else if (utils.isCD()) {

--- a/maven/ReleaseStageApproveAndPromote/Jenkinsfile
+++ b/maven/ReleaseStageApproveAndPromote/Jenkinsfile
@@ -12,8 +12,14 @@ mavenNode {
   checkout scm
   if (utils.isCI()) {
 
-    mavenCI{}
-    
+    mavenCI {
+        integrationTestCmd = "mvn org.apache.maven.plugins:maven-failsafe-plugin:integration-test \
+                            -Dnamespace.use.current=false -Dnamespace.use.existing=${utils.testNamespace()} \
+                            -Dit.test=*IT -DfailIfNoTests=false -DenableImageStreamDetection=true \
+                            org.apache.maven.plugins:maven-failsafe-plugin:verify \
+                            -P openshift-it"
+    }
+
   } else if (utils.isCD()) {
     /*
      * Try to load the script ".openshiftio/Jenkinsfile.setup.groovy".
@@ -28,7 +34,7 @@ mavenNode {
     } catch (Exception ex) {
       echo "Jenkinsfile.setup.groovy not found"
     }
-    
+
     echo 'NOTE: running pipelines for the first time will take longer as build and base docker images are pulled onto the node'
     container(name: 'maven') {
       stage('Build Release') {
@@ -60,7 +66,7 @@ if (utils.isCD()) {
         environment = 'Stage'
       }
     }
-    
+
     stage('Rollout to Run') {
       unstash stashName
       setupScript?.setupEnvironmentPre(envProd)


### PR DESCRIPTION
Maven integration tests are failing because it tries to create a
test namespace (project) on OpenShift, hence call to OpenShift API gets
fail due to permission issue.
This patch fixes the `mavenCI` step by inputting maven command to run
integration test along with valid test namespace.

Resolves:
 - https://github.com/openshiftio/openshift.io/issues/3134
 - https://github.com/openshiftio/openshift.io/issues/763