### PR TITLE
fixes template parameters name in Jenkinsfiles

### DIFF
--- a/golang/Release/Jenkinsfile
+++ b/golang/Release/Jenkinsfile
@@ -7,7 +7,7 @@ osio {
   ci {
 
     def resources = processTemplate(params: [
-          release_version: "1.0.${env.BUILD_NUMBER}"
+          RELEASE_VERSION: "1.0.${env.BUILD_NUMBER}"
     ])
 
     build resources: resources
@@ -17,7 +17,7 @@ osio {
   cd {
 
     def resources = processTemplate(params: [
-          release_version: "1.0.${env.BUILD_NUMBER}"
+          RELEASE_VERSION: "1.0.${env.BUILD_NUMBER}"
     ])
 
     build resources: resources

--- a/golang/ReleaseAndStage/Jenkinsfile
+++ b/golang/ReleaseAndStage/Jenkinsfile
@@ -7,7 +7,7 @@ osio {
   ci {
 
     def resources = processTemplate(params: [
-          release_version: "1.0.${env.BUILD_NUMBER}"
+          RELEASE_VERSION: "1.0.${env.BUILD_NUMBER}"
     ])
 
     build resources: resources
@@ -17,7 +17,7 @@ osio {
   cd {
 
     def resources = processTemplate(params: [
-          release_version: "1.0.${env.BUILD_NUMBER}"
+          RELEASE_VERSION: "1.0.${env.BUILD_NUMBER}"
     ])
 
     build resources: resources

--- a/golang/ReleaseStageApproveAndPromote/Jenkinsfile
+++ b/golang/ReleaseStageApproveAndPromote/Jenkinsfile
@@ -7,7 +7,7 @@ osio {
   ci {
 
     def resources = processTemplate(params: [
-          release_version: "1.0.${env.BUILD_NUMBER}"
+          RELEASE_VERSION: "1.0.${env.BUILD_NUMBER}"
     ])
 
     build resources: resources
@@ -17,7 +17,7 @@ osio {
   cd {
 
     def resources = processTemplate(params: [
-          release_version: "1.0.${env.BUILD_NUMBER}"
+          RELEASE_VERSION: "1.0.${env.BUILD_NUMBER}"
     ])
 
     build resources: resources

--- a/node/Release/Jenkinsfile
+++ b/node/Release/Jenkinsfile
@@ -7,7 +7,7 @@ osio {
   ci {
 
     def resources = processTemplate(params: [
-          release_version: "1.0.${env.BUILD_NUMBER}"
+          RELEASE_VERSION: "1.0.${env.BUILD_NUMBER}"
     ])
 
     build resources: resources
@@ -17,7 +17,7 @@ osio {
   cd {
 
     def resources = processTemplate(params: [
-          release_version: "1.0.${env.BUILD_NUMBER}"
+          RELEASE_VERSION: "1.0.${env.BUILD_NUMBER}"
     ])
 
     build resources: resources

--- a/node/ReleaseAndStage/Jenkinsfile
+++ b/node/ReleaseAndStage/Jenkinsfile
@@ -7,7 +7,7 @@ osio {
   ci {
 
     def resources = processTemplate(params: [
-          release_version: "1.0.${env.BUILD_NUMBER}"
+          RELEASE_VERSION: "1.0.${env.BUILD_NUMBER}"
     ])
 
     build resources: resources
@@ -17,7 +17,7 @@ osio {
   cd {
 
     def resources = processTemplate(params: [
-          release_version: "1.0.${env.BUILD_NUMBER}"
+          RELEASE_VERSION: "1.0.${env.BUILD_NUMBER}"
     ])
 
     build resources: resources

--- a/node/ReleaseStageApproveAndPromote/Jenkinsfile
+++ b/node/ReleaseStageApproveAndPromote/Jenkinsfile
@@ -7,7 +7,7 @@ osio {
   ci {
 
     def resources = processTemplate(params: [
-          release_version: "1.0.${env.BUILD_NUMBER}"
+          RELEASE_VERSION: "1.0.${env.BUILD_NUMBER}"
     ])
 
     build resources: resources
@@ -17,7 +17,7 @@ osio {
   cd {
 
     def resources = processTemplate(params: [
-          release_version: "1.0.${env.BUILD_NUMBER}"
+          RELEASE_VERSION: "1.0.${env.BUILD_NUMBER}"
     ])
 
     build resources: resources


### PR DESCRIPTION
.openshiftio/application.yaml template has RELEASE_VERSION
paremeter not release_version (case mattters). Due to its
case, release_version getting random value in pipeline
processing and it not working as intended.

This patch fixes this issue.

Fixes
 - https://github.com/openshiftio/openshift.io/issues/4749